### PR TITLE
Add explicit package name in demo

### DIFF
--- a/Examples/HummingbirdDemo/Package.swift
+++ b/Examples/HummingbirdDemo/Package.swift
@@ -10,7 +10,10 @@ let package = Package(
         .executable(name: "App", targets: ["App"])
     ],
     dependencies: [
+        // In this demo project we import elementary-htmx from the local file system.
         .package(name: "elementary-htmx", path: "../../"),
+        // In a real project add a remote dependency, e.g.
+        // .package(url: "https://github.com/elementary-swift/elementary-htmx.git", from: "0.5.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", from: "2.0.0"),
         .package(url: "https://github.com/hummingbird-community/hummingbird-elementary.git", from: "0.4.0"),

--- a/Examples/HummingbirdDemo/Package.swift
+++ b/Examples/HummingbirdDemo/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .executable(name: "App", targets: ["App"])
     ],
     dependencies: [
-        .package(path: "../../"),
+        .package(name: "elementary-htmx", path: "../../"),
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", from: "2.0.0"),
         .package(url: "https://github.com/hummingbird-community/hummingbird-elementary.git", from: "0.4.0"),

--- a/Examples/VaporDemo/Package.swift
+++ b/Examples/VaporDemo/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/vapor", from: "4.102.0"),
         .package(url: "https://github.com/vapor-community/vapor-elementary.git", from: "0.2.0"),
-        .package(path: "../../"),
+        .package(name: "elementary-htmx", path: "../../"),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),
     ],
     targets: [

--- a/Examples/VaporDemo/Package.swift
+++ b/Examples/VaporDemo/Package.swift
@@ -12,7 +12,10 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/vapor", from: "4.102.0"),
         .package(url: "https://github.com/vapor-community/vapor-elementary.git", from: "0.2.0"),
+        // In this demo project we import elementary-htmx from the local file system.
         .package(name: "elementary-htmx", path: "../../"),
+        // In a real project add a remote dependency, e.g.
+        // .package(url: "https://github.com/elementary-swift/elementary-htmx.git", from: "0.5.0"),
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),
     ],
     targets: [


### PR DESCRIPTION
This PR contains two commits.

## [explicit package name added to demo projects](https://github.com/elementary-swift/elementary-htmx/commit/2d17e42cb0710467ebd79d9fcd68d59eb575a539)

Without a name the directory name is used as the package name. When downloading the repository directly from GitHub the directory name (and therefore package name) is “elementary-htmx-main”. The incorrect package name causes the demo projects to not build.

Adding explicit package names resolves this issue.

## [added comments for remote dependency to demo](https://github.com/elementary-swift/elementary-htmx/commit/4e1d73a17499908f93b324efb66085509f87aa3a)

When I (as a first time user) were trying to quickly grab the correct imports for elementary-htmx from the demo projects I completely glossed over the local package. Instead I incorrectly guessed that everything would come from the hummingbird-community/hummingbird-elementary package.

I think a comment in the demo project would be a nice way to steer tired eyes in the right direction.

# Discussion

Another way to resolve both issues would be to use a remote dependency in the demo projects instead of the local dependency. I guess a local dependency is used since it makes developing the demo projects in tandem with the elementary-htmx package easier.

I believe either solution is fine and that the issue is not worth giving too much thought :)